### PR TITLE
memory leak

### DIFF
--- a/src/stacktrace.c
+++ b/src/stacktrace.c
@@ -91,6 +91,7 @@ static _Unwind_Reason_Code collect(struct _Unwind_Context *ctx, void *p) {
 
 struct stacktrace *stacktrace_get(unsigned skip) {
     char procf[512];
+    char *new_exec = NULL;
     int len, n;
 
     struct stacktrace *trace = malloc(sizeof(struct stacktrace));
@@ -108,7 +109,13 @@ struct stacktrace *stacktrace_get(unsigned skip) {
     snprintf(procf, sizeof(procf), "/proc/%d/exe", (int)getpid());
 
     for (len = 512; ; len *= 2) {
-        trace->exe = realloc(trace->exe, len);
+        new_exec = realloc(trace->exe, len);
+        if (new_exec == NULL) {
+            free(trace->exe);
+            break ;
+        } else {
+            trace->exe = new_exec;
+        }
 
         n = readlink(procf, trace->exe, len);
         if (n == -1) {


### PR DESCRIPTION
       realloc() changes the size of the memory block pointed to by ptr to size bytes.  The contents will be unchanged to the minimum of the old and new sizes; newly allocated memory will be uninitialized.  If ptr
       is  NULL, then the call is equivalent to malloc(size), for all values of size; if size is equal to zero, and ptr is not NULL, then the call is equivalent to free(ptr).  Unless ptr is NULL, it must have been
       returned by an earlier call to malloc(), calloc() or realloc().  If the area pointed to was moved, a free(ptr) is done.

       realloc()  returns  a  pointer  to the newly allocated memory, which is suitably aligned for any kind of variable and may be different from ptr, or NULL if the request fails.  If size was equal to 0, either
       NULL or a pointer suitable to be passed to free() is returned.  If realloc() fails the original block is left untouched; it is not freed or moved.
